### PR TITLE
Fix #AR-3985 standard contract readme file in public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,48 @@
+<p align="center">
+<a href="#start"><img height="30rem" src="https://raw.githubusercontent.com/arcana-network/branding/main/an_logo_light_temp.png"/></a>
+</p>
+<p align="center">
+<a title="MIT License" href="https://github.com/arcana-network/license/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-blue"/></a>
+<a title="Beta release" href="https://github.com/arcana-network/arcana-standard-contracts/releases"><img src="https://img.shields.io/github/v/release/arcana-network/arcana-standard-contracts?style=flat-square&color=28A745"/></a>
+<a title="Twitter" href="https://twitter.com/ArcanaNetwork"><img alt="Twitter URL" src="https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2FArcanaNetwork"/></a>
+</p>
+
 # Arcana Standard Contracts
 
 This project contains ERC standard contracts with Arcana supported functions.
 
+*Need to add the purpose of this repository and why it is public. Who needs to use it and when.*
 
-## Contracts
+## AERC721 Contract
 
-### AERC721: 
+The AERC721 is a standard set of interfaces implemented by Arcana Protocol for issuing Non-Fungible Tokens or NFTs residing on the Arcana Network.
 
-The ARC721 is a standard set of interfaces for issuing non-fungible tokens for NFTs residing on Arcana Network. It is fully compatible with the standard [ERC721](https://docs.openzeppelin.com/contracts/3.x/erc721)) interface. 
+It is fully compatible with the standard [ERC721](https://docs.openzeppelin.com/contracts/3.x/erc721)) interface with just one execption. There is an additional hook method `_beforeTokenTransfer_`.
 
-AERC721 is similar to standard ERC721 with just one execption. There is an additional hook method `_beforeTokenTransfer_`. This method is added to initiate a call to Arcana Network bridge contract. Bridge allows Arcana Network to listen for NFT mint/transfer on-chain operations that happen on the supported chains. Currently, Mumbai and Ropsten are supported.
+This additional hook method is added to setup communication with Arcana Network bridge contract. Bridge allows Arcana Network to listen for NFT mint/transfer on-chain operations that happen on the supported chains. Currently, Mumbai and Ropsten are supported.
 
+## ⚙️ Installation
 
-## Usage
-
-Install dependencies
+Install software dependencies:
 
 ```bash
-npm i
+npm install
 ```
 
-### Deploy to Mumbai Network
+## 📚 Usage
 
-The contract in directly is ownable NFT collection i.e. Only deployer can mint the NFT. 
+After installation, you can deploy it to the supported chains and then customize it.
+
+### Supported Chains
+
+* [Polygon MUMBAI Testnet](https://docs.unbound.finance/guides/guide-to-accessing-polygon-testnet-and-how-to-use-unbound-faucet-tokens)
+* [Ethereum Ropsten Testnet](https://www.alchemy.com/overviews/ropsten-testnet#ropsten-1)
+
+### Deployment
+
+#### MUMBAI Testnet
+
+The contract in directly is ownable NFT collection i.e. Only deployer can mint the NFT.
 
 **Environment Variables:**
 - CONTRACT_OWNER : Contract deployer account having funds on Polygon MUMBAI network
@@ -37,7 +57,11 @@ npx hardhat run scripts/deploy.js --network mumbai
 
 ```
 
-### How to customize NFT Contract
+#### Other Chains
+
+TBD - How to deploy instructions
+
+### Customize NFT Contract
 
 You can customize the NFT contract as per your needs. Make sure that you do not miss to include the `bridge call` in the contract. This call enables Arcana Network to listen for NFT transfers and record any ownership changes.
 
@@ -66,7 +90,20 @@ function _beforeTokenTransfer(
         IBridge(bridgeContractAddress).transferData(to, address(this), tokenId);
 }
 
-
 ```
 
+## 💡 Support
 
+For any support or integration related queries, contact [Arcana support team](mailto:support@arcana.network).
+
+## 🤝 Contributing
+
+We welcome all contributions to this public repository from the community.
+
+Read our [contributing guide](https://github.com/arcana-network/license/blob/main/CONTRIBUTING.md) to learn more about the our development process, how to propose bug fixes and improvements, and the code of conduct that we expect the participants to adhere to.
+
+## ℹ️ License
+
+Arcana Network Drive is distributed under the [MIT License](https://fossa.com/blog/open-source-licenses-101-mit-license/).
+
+For details see [Arcana License](https://github.com/arcana-network/license/blob/main/LICENSE.md).

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -27,7 +27,7 @@ module.exports = {
     hardhat: {},
     mumbai: {
       url: mumbai_url,
-      chainId: 1337,
+      chainId: 80001,
       accounts: [deployer]
     }    
 

--- a/scripts/mint.js
+++ b/scripts/mint.js
@@ -10,7 +10,7 @@ async function main() {
     const AERC721_factory = await hre.ethers.getContractFactory("AERC721");
     const AERC721 = await AERC721_factory.attach(nftContractAddress)
 
-    let tx = await AERC721.mint(to, tokenId);
+    let tx = await AERC721.mint(to, tokenId, tokenUri);
     await tx.wait();
 
     console.log(`Minted token ${tokenId} \nto ${to}`);


### PR DESCRIPTION
Ref [AR-3985](https://team-1624093970686.atlassian.net/browse/AR-3985) and https://team-1624093970686.atlassian.net/browse/AR-3945 Readme review, need to conform all Arcana Public Readme files in GitHub repos to a basic simple text template agreed upon by the team [here](https://team-1624093970686.atlassian.net/l/cp/rwYKN135).